### PR TITLE
feat: add submarine collision for Ocean Shooter

### DIFF
--- a/lib/challenges/challenge_type_enum.dart
+++ b/lib/challenges/challenge_type_enum.dart
@@ -93,7 +93,7 @@ enum ChallengeType {
     title: 'Plastic Free',
     description: 'Oceans are polluted with plastics. Cleaning them helps marine life thrive.',
     instruction1: 'Use platformKey to move the ship and aim to shoot micro-plastics.',
-    instruction2: 'Earn 1 point for each plastic shot in 30 seconds. Avoid hits - each will cost you 1 point!',
+    instruction2: 'Earn 1 point for each plastic shot in 30 seconds. Avoid hits - each one will cost you 1 point!',
     instructionAsset1: AssetPaths.infoPlastics1,
     instructionAsset2: AssetPaths.infoPlastics2,
     completedText: 'Your dedication to removing plastics\nkeeps our oceans clean and marine life safe.',

--- a/lib/challenges/challenge_type_enum.dart
+++ b/lib/challenges/challenge_type_enum.dart
@@ -93,7 +93,7 @@ enum ChallengeType {
     title: 'Plastic Free',
     description: 'Oceans are polluted with plastics. Cleaning them helps marine life thrive.',
     instruction1: 'Use platformKey to move the ship and aim to shoot micro-plastics.',
-    instruction2: 'Earn 1 point for each plastic shot in 30 seconds.',
+    instruction2: 'Earn 1 point for each plastic shot in 30 seconds. Avoid hits - each will cost you 1 point!',
     instructionAsset1: AssetPaths.infoPlastics1,
     instructionAsset2: AssetPaths.infoPlastics2,
     completedText: 'Your dedication to removing plastics\nkeeps our oceans clean and marine life safe.',

--- a/lib/challenges/lights_out_challenge/lights_out_runner.dart
+++ b/lib/challenges/lights_out_challenge/lights_out_runner.dart
@@ -39,7 +39,7 @@ class LightsOutRunner extends FlameGame<LightsOutWorld> with HasCollisionDetecti
 
   @override
   KeyEventResult onKeyEvent(
-    RawKeyEvent event,
+    KeyEvent event,
     Set<LogicalKeyboardKey> keysPressed,
   ) {
     final isSpace = keysPressed.contains(LogicalKeyboardKey.space);

--- a/lib/challenges/ocean_shooter/components/player_component.dart
+++ b/lib/challenges/ocean_shooter/components/player_component.dart
@@ -4,11 +4,12 @@ import 'package:better_world/challenges/ocean_shooter/components/bullet_componen
 import 'package:better_world/challenges/ocean_shooter/components/enemy_component.dart';
 import 'package:better_world/challenges/ocean_shooter/components/explosion_component.dart';
 import 'package:better_world/challenges/ocean_shooter/components/fire_boost_component.dart';
+import 'package:better_world/challenges/ocean_shooter/ocean_challenge_game.dart';
 import 'package:better_world/common/asset_paths.dart';
 import 'package:flame/collisions.dart';
 import 'package:flame/components.dart';
 
-class PlayerComponent extends SpriteAnimationComponent with HasGameRef, CollisionCallbacks {
+class PlayerComponent extends SpriteAnimationComponent with HasGameRef<OceanChallengeGame>, CollisionCallbacks {
   PlayerComponent({required this.audioController})
       : super(
           size: Vector2(117, 71),
@@ -50,7 +51,7 @@ class PlayerComponent extends SpriteAnimationComponent with HasGameRef, Collisio
   void beginFire() {
     add(
       bulletCreator = TimerComponent(
-        period: 1,
+        period: 0.5,
         repeat: true,
         autoStart: true,
         onTick: () => _createBullet(_initialBulletAngles),
@@ -65,6 +66,7 @@ class PlayerComponent extends SpriteAnimationComponent with HasGameRef, Collisio
 
   void takeHit() {
     game.add(ExplosionComponent(position: position));
+    game.decreaseScore();
   }
 
   @override
@@ -75,7 +77,7 @@ class PlayerComponent extends SpriteAnimationComponent with HasGameRef, Collisio
     super.onCollisionStart(intersectionPoints, other);
 
     if (other is EnemyComponent) {
-      game.add(ExplosionComponent(position: position));
+      takeHit();
       other.removeFromParent();
     } else if (other is FireBoostComponent) {
       remove(bulletCreator);

--- a/lib/challenges/ocean_shooter/ocean_challenge_game.dart
+++ b/lib/challenges/ocean_shooter/ocean_challenge_game.dart
@@ -55,7 +55,7 @@ class OceanChallengeGame extends FlameGame with PanDetector, HasCollisionDetecti
   }
 
   @override
-  KeyEventResult onKeyEvent(RawKeyEvent event, Set<LogicalKeyboardKey> keysPressed) {
+  KeyEventResult onKeyEvent(KeyEvent event, Set<LogicalKeyboardKey> keysPressed) {
     if (keysPressed.contains(LogicalKeyboardKey.arrowLeft)) {
       player.position.x -= _playerSpeed;
       player.position.x = player.position.x.clamp(0, size.x - player.size.x);
@@ -88,6 +88,14 @@ class OceanChallengeGame extends FlameGame with PanDetector, HasCollisionDetecti
 
     if (score == 15) {
       add(FireBoostCreator(audioController: audioController));
+    }
+  }
+
+  void decreaseScore() {
+    if (score <= 1) {
+      score = 0;
+    } else {
+      score--;
     }
   }
 }

--- a/lib/challenges/ocean_shooter/ocean_challenge_screen.dart
+++ b/lib/challenges/ocean_shooter/ocean_challenge_screen.dart
@@ -30,6 +30,7 @@ class OceanChallengeScreen extends StatelessWidget {
   static const String appBarKey = 'appBar';
   static const String introductionDialogKey = 'introductionDialog';
   static const String countDownKey = 'countDown';
+  static const String decreaseScoreKey = 'decreaseScore';
 
   @override
   Widget build(BuildContext context) {

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -19,7 +19,7 @@ import wakelock_plus
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AudioplayersDarwinPlugin.register(with: registry.registrar(forPlugin: "AudioplayersDarwinPlugin"))
   FLTFirebaseFirestorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseFirestorePlugin"))
-  ConnectivityPlugin.register(with: registry.registrar(forPlugin: "ConnectivityPlugin"))
+  ConnectivityPlusPlugin.register(with: registry.registrar(forPlugin: "ConnectivityPlusPlugin"))
   FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))


### PR DESCRIPTION
## Description
- when submarine hits the micro plastic, one point is deducted
- we don't allow score lower than 0
- I increased the speed of adding new fire bullets
- I didn't add the animation for the HUD yet

## How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes. For larger features, provide
reproducible instructions.
-->

## Screenshots


https://github.com/appunite/flutter-global-gamers-challenge/assets/83956577/6c5bab2a-639c-4e89-99d1-0f255f3dc467


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] 🗑️ Chore
